### PR TITLE
🔴 Security hardening + RIR UX fix + logging cleanup

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,59 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: "X-DNS-Prefetch-Control",
+    value: "on",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "SAMEORIGIN",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      // Next.js requires 'unsafe-inline' for styles and inline scripts
+      "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://va.vercel-scripts.com",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src 'self' https://fonts.gstatic.com",
+      // Supabase API + auth
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://generativelanguage.googleapis.com https://va.vercel-scripts.com",
+      "img-src 'self' data: blob: https://*.supabase.co https://avatars.githubusercontent.com",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join("; "),
+  },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,16 @@
+User-agent: *
+
+# Allow public pages
+Allow: /
+Allow: /login
+Allow: /signup
+
+# Disallow authenticated routes
+Disallow: /dashboard
+Disallow: /workout
+Disallow: /history
+Disallow: /profile
+Disallow: /api/
+
+Sitemap: https://aura-strength.vercel.app/sitemap.xml
+

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,5 +12,4 @@ Disallow: /history
 Disallow: /profile
 Disallow: /api/
 
-Sitemap: https://aura-strength.vercel.app/sitemap.xml
 

--- a/src/app/api/coach/route.ts
+++ b/src/app/api/coach/route.ts
@@ -118,7 +118,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    console.log(`[API /coach] Request from user: ${user.id}`);
+    const userId = user.id;
+    const safeUserId = process.env.NODE_ENV === 'production'
+      ? `${userId.slice(0, 8)}...`
+      : userId;
+    console.log(`[API /coach] Request from user: ${safeUserId}`);
 
     // 2. Parse and validate request body
     const body = await request.json();
@@ -166,9 +170,9 @@ Give ONE short coaching note (max 15 words). Be specific and actionable. No gree
     }
 
     // 3. Check rate limit (workout generation only — not set_note)
-    const rateLimit = checkRateLimit(user.id);
+    const rateLimit = checkRateLimit(userId);
     if (!rateLimit.allowed) {
-      console.warn(`[API /coach] Rate limit exceeded for user: ${user.id}`);
+      console.warn(`[API /coach] Rate limit exceeded for user: ${safeUserId}`);
       return NextResponse.json(
         {
           error: 'Too Many Requests',
@@ -198,7 +202,7 @@ Give ONE short coaching note (max 15 words). Be specific and actionable. No gree
     // 4. Build AI context (fetches user data from Supabase)
     let context;
     try {
-      context = await buildAIContext(user.id, workoutType);
+      context = await buildAIContext(userId, workoutType);
       console.log(
         `[API /coach] Context built successfully:`,
         `User: ${context.userProfile.userId}`,
@@ -209,7 +213,7 @@ Give ONE short coaching note (max 15 words). Be specific and actionable. No gree
     } catch (error) {
       console.error('[API /coach] Error building context:', error);
       console.error('[API /coach] Error details:', {
-        userId: user.id,
+        userId: safeUserId,
         workoutType,
         errorMessage: error instanceof Error ? error.message : String(error),
         errorStack: error instanceof Error ? error.stack : undefined,
@@ -231,7 +235,6 @@ Give ONE short coaching note (max 15 words). Be specific and actionable. No gree
 
     // 6. Call Gemini AI
     console.log('[API /coach] Calling Gemini AI...');
-    console.log('[API /coach] Using API key:', process.env.GOOGLE_GENERATIVE_AI_API_KEY ? 'SET (length: ' + process.env.GOOGLE_GENERATIVE_AI_API_KEY.length + ')' : 'NOT SET');
 
     let result;
     try {
@@ -246,12 +249,16 @@ Give ONE short coaching note (max 15 words). Be specific and actionable. No gree
 
       console.log('[API /coach] AI generation complete');
     } catch (error: unknown) {
-      console.error('[API /coach] Gemini API error:', error);
-      console.error('[API /coach] Error type:', error?.constructor?.name);
-      console.error('[API /coach] Error details:', JSON.stringify(error, null, 2));
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      // Only log full details in development to avoid leaking internals
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('[API /coach] Gemini API error:', error);
+        console.error('[API /coach] Error type:', error instanceof Error ? error.constructor.name : typeof error);
+      } else {
+        console.error('[API /coach] Gemini API error:', errorMessage.slice(0, 200));
+      }
 
       // Handle specific API errors
-      const errorMessage = error instanceof Error ? error.message : String(error);
 
       if (errorMessage.includes('API key')) {
         return NextResponse.json(

--- a/src/app/profile/setup/page.tsx
+++ b/src/app/profile/setup/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import AuraBackground from '@/components/aura/AuraBackground'
@@ -16,6 +16,21 @@ export default function ProfileSetupPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [equipment, setEquipment] = useState<EquipmentByGroup>(EMPTY_EQUIPMENT)
+  const [authChecked, setAuthChecked] = useState(false)
+
+  // Auth guard: redirect unauthenticated users on page load
+  useEffect(() => {
+    const checkAuth = async () => {
+      const supabase = createClient()
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        router.replace('/login')
+        return
+      }
+      setAuthChecked(true)
+    }
+    checkAuth()
+  }, [router])
 
   const [formData, setFormData] = useState({
     age: '',
@@ -100,6 +115,18 @@ export default function ProfileSetupPage() {
     } finally {
       setLoading(false)
     }
+  }
+
+  // Show nothing until auth check completes (middleware handles redirect)
+  if (!authChecked) {
+    return (
+      <>
+        <AuraBackground />
+        <div className="min-h-screen flex items-center justify-center">
+          <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
+        </div>
+      </>
+    )
   }
 
   return (

--- a/src/app/workout/session/[id]/page.tsx
+++ b/src/app/workout/session/[id]/page.tsx
@@ -177,7 +177,18 @@ export default function WorkoutSessionPage() {
       } catch {
         if (!cancelled) setExercisePRHistory([]);
       }
-      if (!cancelled) setAiNote(null);
+      // Reset inputs for new exercise — pre-fill RIR from target
+      if (!cancelled) {
+        setAiNote(null);
+        setWeight('');
+        setReps('');
+        const defaultRIR = currentExercise?.targetRIR
+          ? currentExercise.targetRIR.split('-')[0].trim()
+          : '';
+        setRir(defaultRIR);
+        setSelectedTags([]);
+        setFeedbackNote('');
+      }
     };
     fetchPRHistory();
     return () => { cancelled = true; };
@@ -306,10 +317,13 @@ export default function WorkoutSessionPage() {
         }
       });
 
-      // Clear inputs
+      // Clear inputs — pre-fill RIR with target to avoid confusion
+      const targetRIRDefault = currentExercise?.targetRIR
+        ? currentExercise.targetRIR.split('-')[0].trim()
+        : '';
       setWeight('');
       setReps('');
-      setRir('');
+      setRir(targetRIRDefault);
       setSelectedTags([]);
       setFeedbackNote('');
 

--- a/src/app/workout/session/[id]/page.tsx
+++ b/src/app/workout/session/[id]/page.tsx
@@ -182,9 +182,7 @@ export default function WorkoutSessionPage() {
         setAiNote(null);
         setWeight('');
         setReps('');
-        const defaultRIR = currentExercise?.targetRIR
-          ? currentExercise.targetRIR.split('-')[0].trim()
-          : '';
+        const defaultRIR = currentExercise?.targetRIR?.split?.('-')?.[0]?.trim() || '';
         setRir(defaultRIR);
         setSelectedTags([]);
         setFeedbackNote('');
@@ -318,9 +316,8 @@ export default function WorkoutSessionPage() {
       });
 
       // Clear inputs — pre-fill RIR with target to avoid confusion
-      const targetRIRDefault = currentExercise?.targetRIR
-        ? currentExercise.targetRIR.split('-')[0].trim()
-        : '';
+      const targetRIRDefault =
+        currentExercise?.targetRIR?.split?.('-')?.[0]?.trim() || '';
       setWeight('');
       setReps('');
       setRir(targetRIRDefault);

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,6 +1,12 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
+// Routes that require authentication
+const PROTECTED_ROUTES = ['/dashboard', '/workout', '/history', '/profile']
+
+// Routes that should redirect to dashboard when already authenticated
+const AUTH_ROUTES = ['/login', '/signup']
+
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
@@ -15,7 +21,7 @@ export async function updateSession(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => request.cookies.set(name, value))
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({
             request,
           })
@@ -27,9 +33,28 @@ export async function updateSession(request: NextRequest) {
     }
   )
 
-  // Refreshing the auth token
-  await supabase.auth.getUser()
+  // Refresh the auth token and get the current user
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { pathname } = request.nextUrl
+
+  // Redirect unauthenticated users away from protected routes
+  const isProtected = PROTECTED_ROUTES.some((route) => pathname.startsWith(route))
+  if (isProtected && !user) {
+    const loginUrl = request.nextUrl.clone()
+    loginUrl.pathname = '/login'
+    return NextResponse.redirect(loginUrl)
+  }
+
+  // Redirect authenticated users away from auth pages
+  const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route))
+  if (isAuthRoute && user) {
+    const dashboardUrl = request.nextUrl.clone()
+    dashboardUrl.pathname = '/dashboard'
+    return NextResponse.redirect(dashboardUrl)
+  }
 
   return supabaseResponse
 }
-

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -21,7 +21,8 @@ export async function updateSession(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          cookiesToSet.forEach(({ name, value, options: _o }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({
             request,
           })


### PR DESCRIPTION
## Summary
Addresses critical and medium security issues identified in the comprehensive app test report (Feb 22, 2026).

## Changes

### 🔴 Critical — Security Headers (#61)
Added comprehensive HTTP security headers to `next.config.ts`:
- **HSTS** — `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- **Clickjacking** — `X-Frame-Options: SAMEORIGIN`
- **MIME sniffing** — `X-Content-Type-Options: nosniff`
- **Referrer** — `Referrer-Policy: strict-origin-when-cross-origin`
- **Permissions** — `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- **CSP** — Content Security Policy scoped to Supabase + Gemini + Vercel Analytics

### 🔴 Critical — Centralized Route Protection (#62)
Updated `src/lib/supabase/middleware.ts`:
- Unauthenticated users visiting `/dashboard`, `/workout`, `/history`, `/profile` are redirected to `/login`
- Authenticated users visiting `/login` or `/signup` are redirected to `/dashboard`
- Single source of truth — no more per-page auth checks required

### 🔴 Critical — Profile Setup Auth Guard (#62)
Added `useEffect` auth guard to `profile/setup/page.tsx`:
- Checks auth on page load (not just on form submit)
- Shows spinner while checking; redirects to `/login` if not authenticated

### 🟡 Medium — RIR Input UX Fix (#64)
Fixed confusing "Log Set disabled" UX in workout session page:
- RIR field is now **pre-filled** with the target RIR when an exercise loads and after each set is logged
- Previously the placeholder `"2"` looked like a value but wasn't, leaving users wondering why the button was disabled

### 🟡 Medium — API Logging Cleanup (#64)
In `src/app/api/coach/route.ts`:
- Removed API key length leak from logs
- Sanitized user IDs (truncated to 8 chars in production)
- Capped Gemini error detail to 200 chars in production
- Full error details still logged in development

### 🟢 Low — robots.txt (#64)
Added `public/robots.txt` blocking search engines from authenticated routes (`/dashboard`, `/workout`, `/history`, `/profile`, `/api/`).

## Issues Closed
- Closes #61
- Closes #62
- Partially addresses #64